### PR TITLE
Fix log level for successful invocations

### DIFF
--- a/zerolog.go
+++ b/zerolog.go
@@ -70,9 +70,11 @@ func (l *logger) LogEvent(event fxevent.Event) {
 		msg := "invoked"
 		if e.Err != nil {
 			msg = "invoke failed"
+			l.Logger.Error().Err(e.Err).Str("stack", e.Trace).
+				Str("function", e.FunctionName).Msg(msg)
+		} else {
+			l.Logger.Info().Str("function", e.FunctionName).Msg(msg)
 		}
-		l.Logger.Error().Err(e.Err).Str("stack", e.Trace).
-			Str("function", e.FunctionName).Msg(msg)
 	case *fxevent.Stopping:
 		l.Logger.Info().Str("signal", strings.ToUpper(e.Signal.String())).Msg("received signal")
 	case *fxevent.Stopped:

--- a/zerolog_test.go
+++ b/zerolog_test.go
@@ -103,7 +103,7 @@ func TestFxlogger(t *testing.T) {
 		{
 			name:        "Invoked/Success",
 			give:        &fxevent.Invoked{FunctionName: "bytes.NewBuffer()"},
-			wantMessage: "{\"level\":\"error\",\"stack\":\"\",\"function\":\"bytes.NewBuffer()\",\"message\":\"invoked\"}\n",
+			wantMessage: "{\"level\":\"info\",\"function\":\"bytes.NewBuffer()\",\"message\":\"invoked\"}\n",
 		},
 		{
 			name:        "Invoked/Error",


### PR DESCRIPTION
Discovered [here](https://github.com/uber-go/fx/issues/770) and fixed [here](https://github.com/uber-go/fx/pull/771/files).